### PR TITLE
Fix docs deployment and CI env list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,30 +21,28 @@ jobs:
     name: Lint and build
     runs-on: ubuntu-latest
 
-    # Use deterministic mock values so CI never depends on maintainer-only secrets.
-    # Production deployments should be handled by Vercel or a separate protected workflow.
+    # Keep this list aligned with the repository secrets currently configured.
+    # Do not add STELLAR_* variables here until those secrets exist in GitHub/Vercel.
     env:
-      NEXT_PUBLIC_APP_URL: http://localhost:3000
-      MONGODB_URI: mongodb://127.0.0.1:27017/chainmove_ci
-      JWT_SECRET: ci_mock_jwt_secret_do_not_use_in_production
-      AUTH_SESSION_SECRET: ci_mock_session_secret_do_not_use_in_production
-      KYC_DOCUMENT_ENCRYPTION_KEY: ci_mock_kyc_secret_do_not_use_in_production
-      NEXT_PUBLIC_PRIVY_APP_ID: ci_mock_privy_app_id
-      PRIVY_APP_ID: ci_mock_privy_app_id
-      PRIVY_APP_SECRET: ci_mock_privy_secret
-      PRIVY_JWKS_URL: https://auth.privy.io/api/v1/apps/ci_mock_privy_app_id/jwks.json
-      PAYSTACK_PUBLIC_KEY: pk_test_mock
-      PAYSTACK_SECRET_KEY: sk_test_mock
-      PAYSTACK_DVA_PREFERRED_BANK: test-bank
-      RESEND_API_KEY: re_mock
-      BLOB_READ_WRITE_TOKEN: vercel_blob_mock
-      STELLAR_NETWORK: testnet
-      STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
-      STELLAR_RPC_URL: https://soroban-testnet.stellar.org
-      STELLAR_ASSET_CODE: CMOVE
-      STELLAR_ISSUER_PUBLIC_KEY: GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
-      STELLAR_DISTRIBUTION_PUBLIC_KEY: GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
-      STELLAR_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+      ACCOUNT_FACTORY_ADDRESS: ${{ secrets.ACCOUNT_FACTORY_ADDRESS }}
+      ALGORITHM: ${{ secrets.ALGORITHM }}
+      BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      CHAINMOVE_CA: ${{ secrets.CHAINMOVE_CA }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      MONGODB_URI: ${{ secrets.MONGODB_URI }}
+      NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+      NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID }}
+      PAYSTACK_PUBLIC_KEY: ${{ secrets.PAYSTACK_PUBLIC_KEY }}
+      PAYSTACK_SECRET_KEY: ${{ secrets.PAYSTACK_SECRET_KEY }}
+      PRIVY_APP_SECRET: ${{ secrets.PRIVY_APP_SECRET }}
+      PRIVY_JWKS_URL: ${{ secrets.PRIVY_JWKS_URL }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      RPC_URL: ${{ secrets.RPC_URL }}
+      SECRET_KEY_HEX: ${{ secrets.SECRET_KEY_HEX }}
+      THIRDWEB_CLIENT_ID: ${{ secrets.THIRDWEB_CLIENT_ID }}
+      THIRDWEB_SECRET_KEY: ${{ secrets.THIRDWEB_SECRET_KEY }}
+      TREASURY_ADDRESS: ${{ secrets.TREASURY_ADDRESS }}
+      TREASURY_PK_KEY: ${{ secrets.TREASURY_PK_KEY }}
       ENABLE_MOCK_PAYMENTS: "true"
       ENABLE_MOCK_EMAILS: "true"
       ENABLE_MOCK_STELLAR: "true"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "chainmove-documentation",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "node ./scripts/build-docs.mjs"
+  }
+}

--- a/docs/scripts/build-docs.mjs
+++ b/docs/scripts/build-docs.mjs
@@ -1,0 +1,92 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;")
+}
+
+const root = process.cwd()
+const publicDir = resolve(root, "public")
+const sourceFile = resolve(root, "contributor-safety-and-stellar-roadmap.md")
+const outputFile = resolve(publicDir, "index.html")
+
+const markdown = await readFile(sourceFile, "utf8")
+const escapedMarkdown = escapeHtml(markdown)
+
+const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ChainMove Documentation</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+
+      body {
+        margin: 0;
+        padding: 48px 20px;
+      }
+
+      main {
+        max-width: 980px;
+        margin: 0 auto;
+        background: #ffffff;
+        border: 1px solid #e2e8f0;
+        border-radius: 24px;
+        box-shadow: 0 24px 80px rgba(15, 23, 42, 0.08);
+        overflow: hidden;
+      }
+
+      header {
+        padding: 32px;
+        border-bottom: 1px solid #e2e8f0;
+        background: linear-gradient(135deg, #fff7ed, #eff6ff);
+      }
+
+      h1 {
+        margin: 0 0 8px;
+        font-size: clamp(2rem, 4vw, 3rem);
+        line-height: 1.05;
+      }
+
+      p {
+        margin: 0;
+        color: #475569;
+        font-size: 1rem;
+      }
+
+      pre {
+        margin: 0;
+        padding: 32px;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font: 14px/1.7 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>ChainMove Documentation</h1>
+        <p>Contributor safety, CI, mock mode, and integration roadmap.</p>
+      </header>
+      <pre>${escapedMarkdown}</pre>
+    </main>
+  </body>
+</html>
+`
+
+await mkdir(publicDir, { recursive: true })
+await writeFile(outputFile, html, "utf8")
+console.log("Built ChainMove documentation to public/index.html")

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "public",
+  "installCommand": "npm install"
+}


### PR DESCRIPTION
## Summary

This fixes the failing `chainmove-documentation` deployment and aligns CI env variables with the secrets currently configured in GitHub.

## Changes

- Removes all `STELLAR_*` values from the CI env section.
- Adds only the repository secret names currently configured by the maintainer.
- Adds a minimal static docs build under `docs/` for the separate Vercel `chainmove-documentation` project.
- Adds `docs/vercel.json` so the documentation project can build to `docs/public`.

## Notes

The `chainmove-documentation` check is a Vercel project check, not a GitHub Actions workflow in this repo. This PR makes the `docs/` folder buildable so the connected Vercel documentation project can pass. If you still want to remove the check completely, it must be disconnected or disabled inside Vercel project settings.

## Test plan

CI should run:

```bash
npm ci
npm run lint
npm run typecheck --if-present
npm run build
```

For docs project root:

```bash
cd docs
npm install
npm run build
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enabled automated documentation generation and deployment capabilities.

* **Chores**
  * Updated CI configuration to securely use repository secrets for environment settings.
  * Added deployment configuration for documentation infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->