### PR TITLE
Fix Vercel docs root directory

### DIFF
--- a/docs/chainmove-docs/index.html
+++ b/docs/chainmove-docs/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ChainMove Documentation</title>
+  </head>
+  <body>
+    <main style="max-width:900px;margin:40px auto;font-family:Arial,sans-serif;line-height:1.6;padding:0 20px">
+      <h1>ChainMove Documentation</h1>
+      <p>This is the static documentation root for the Vercel chainmove-documentation project.</p>
+      <p>The build command copies the main contributor safety and roadmap document into the public output folder.</p>
+    </main>
+  </body>
+</html>

--- a/docs/chainmove-docs/package.json
+++ b/docs/chainmove-docs/package.json
@@ -2,8 +2,7 @@
   "name": "chainmove-documentation",
   "version": "0.1.0",
   "private": true,
-  "type": "module",
   "scripts": {
-    "build": "node ./scripts/build-docs.mjs"
+    "build": "mkdir -p public && cp ../contributor-safety-and-stellar-roadmap.md public/index.md && printf '<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><title>ChainMove Documentation</title></head><body><main style=\"max-width:900px;margin:40px auto;font-family:Arial,sans-serif;line-height:1.6;padding:0 20px\"><h1>ChainMove Documentation</h1><p>The documentation file is available here:</p><p><a href=\"/index.md\">Open ChainMove documentation</a></p></main></body></html>' > public/index.html"
   }
 }

--- a/docs/chainmove-docs/package.json
+++ b/docs/chainmove-docs/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "chainmove-documentation",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node ./scripts/build-docs.mjs"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the failing `Vercel – chainmove-documentation` deployment.

## Root cause

Vercel is configured with this Root Directory:

```text
docs/chainmove-docs
```

The deployment failed because that directory did not exist in the repository.

## Changes

- Adds the missing `docs/chainmove-docs/` directory.
- Adds `docs/chainmove-docs/package.json` with a simple static build command.
- Adds `docs/chainmove-docs/index.html` as a fallback static page.
- The build command copies the existing docs markdown into `public/index.md` and writes `public/index.html`.

## Test plan

From the configured Vercel root directory:

```bash
cd docs/chainmove-docs
npm run build
```

Expected output:

```text
public/index.html
public/index.md
```
